### PR TITLE
Test fix: Use "core" Fauna Dev Docker image instead of "enterprise" (v4)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
         enum: ["stable", "nightly"]
     resource_class: large
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk
+      - image: mcr.microsoft.com/dotnet/sdk:5.0
 
       - image: gcr.io/faunadb-cloud/faunadb/core/<<parameters.version>>:latest
         name: core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk
 
-      - image: gcr.io/faunadb-cloud/faunadb/enterprise/<<parameters.version>>:latest
+      - image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
         name: core
         auth:
           username: _json_key

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk
 
-      - image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
+      - image: gcr.io/faunadb-cloud/faunadb/core/<<parameters.version>>:latest
         name: core
         auth:
           username: _json_key

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   faunadb:
-    image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
+    image: gcr.io/faunadb-cloud/faunadb/core/stable:latest
     container_name: faunadb
     healthcheck:
       test: ["CMD", "curl" ,"http://faunadb:8443/ping"]

--- a/concourse/tasks/integration.yml
+++ b/concourse/tasks/integration.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   faunadb:
-    image: gcr.io/faunadb-cloud/faunadb/enterprise/stable:latest
+    image: gcr.io/faunadb-cloud/faunadb/core/nightly:latest
     container_name: faunadb
     healthcheck:
       test: ["CMD", "curl" ,"http://faunadb:8443/ping"]


### PR DESCRIPTION
This is a modified cherry-pick of https://github.com/fauna/faunadb-csharp/pull/185; v4 driver needs to support both "stable" and "nightly" flavors of the build, which is the primary difference from the v5 branch.

The CircleCI workflow will test this change via existing test automation.